### PR TITLE
Proposal for a more backward compatible API

### DIFF
--- a/techLogger.js
+++ b/techLogger.js
@@ -307,11 +307,6 @@ function _getCallerFile() {
 
         while (err.stack.length) {
             nextfile = err.stack.shift().getFileName();
-            /*
-            console.log("Current file", currentfile);
-            console.log("Nextfile", nextfile);
-            console.log("Callerfile", callerfile);
-            */
 
             if (nextfile === "module.js") {
                 callerfile = currentfile;

--- a/techLogger.js
+++ b/techLogger.js
@@ -39,36 +39,7 @@ var levelsConfig = {
 // Make winston aware of these colors
 winston.addColors(levelsConfig.colors);
 
-module.exports = function(prefix) {
-
-    /**
-     * Compute caller file name to use it as prefix
-     */
-    function _getCallerFile() {
-        var originalFunc = Error.prepareStackTrace;
-
-        var callerfile;
-        try {
-            var err = new Error();
-            var currentfile;
-
-            Error.prepareStackTrace = function(err, stack) {
-                return stack;
-            };
-
-            currentfile = err.stack.shift().getFileName();
-
-            while (err.stack.length) {
-                callerfile = err.stack.shift().getFileName();
-
-                if (currentfile !== callerfile) break;
-            }
-        } catch (e) {}
-
-        Error.prepareStackTrace = originalFunc;
-
-        return (callerfile ? callerfile.split(path.sep).pop() : callerfile);
-    }
+function _makeLogger(prefix) {
 
     var logPrefix = "[" + (prefix ? prefix : _getCallerFile()) + "]";
 
@@ -145,7 +116,7 @@ module.exports = function(prefix) {
             splash(this, app, configuration);
         }
     };
-};
+}
 
 function _prefixLog(log, logPrefix) {
     var prefixedLog = log;
@@ -316,3 +287,50 @@ function _configureSyslogLogger(config) {
         syslogger.setLevels(levelsConfig.levels);
     }
 }
+
+/**
+ * Compute caller file name to use it as prefix
+ */
+function _getCallerFile() {
+    var originalFunc = Error.prepareStackTrace;
+
+    var callerfile;
+    try {
+        var err = new Error();
+        var currentfile, nextfile;
+
+        Error.prepareStackTrace = function(err, stack) {
+            return stack;
+        };
+
+        currentfile = err.stack.shift().getFileName();
+
+        while (err.stack.length) {
+            nextfile = err.stack.shift().getFileName();
+            /*
+            console.log("Current file", currentfile);
+            console.log("Nextfile", nextfile);
+            console.log("Callerfile", callerfile);
+            */
+
+            if (nextfile === "module.js") {
+                callerfile = currentfile;
+                break;
+            } else if (nextfile !== currentfile) {
+                callerfile = nextfile;
+                break;
+            } else {
+                currentfile = nextfile;
+            }
+
+        }
+        callerfile = _.last(err.stack).getFilename();
+    } catch (e) {}
+
+    Error.prepareStackTrace = originalFunc;
+
+    return (callerfile ? callerfile.split(path.sep).pop() : callerfile);
+}
+
+var defaultLogger = _makeLogger();
+module.exports = _.extend(_makeLogger, defaultLogger);

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -1,35 +1,43 @@
 var configuration = require("config");
+
 var logger1 = require("../techLogger")("logger1");
 var logger2 = require("../techLogger")();
-
+var logger3 = require("../techLogger"); // Look ma, same conf as earlier
 
 logger1.setup(configuration.logging);
 logger2.setup(configuration.logging);
-
+logger3.setup(configuration.logging);
 
 logger1.debug("This is a debug log");
 logger2.debug("This is a debug log");
 
 logger1.info("This is an info log");
 logger2.info("This is an info log");
+logger3.info("This is an info log");
 
 logger1.notice("This is a notice log");
 logger2.notice("This is a notice log");
+logger3.notice("This is a notice log");
 
 logger1.warn("This is a warn log");
 logger2.warn("This is a warn log");
+logger3.warn("This is a warn log");
 
 var apiError = {
     message: "API error message"
 };
 logger1.error("This is an error log", new Error(apiError.message).stack);
 logger2.error("This is an error log", new Error(apiError.message).stack);
+logger3.error("This is an error log", new Error(apiError.message).stack);
 
 logger1.crit("This is a critical log");
 logger2.crit("This is a critical log");
+logger3.crit("This is a critical log");
 
 logger1.alert("This is an alert log");
 logger2.alert("This is an alert log");
+logger3.alert("This is an alert log");
 
 logger1.emerg("This is an emergency log");
 logger2.emerg("This is an emergency log");
+logger3.emerg("This is an emergency log");


### PR DESCRIPTION
Instead of exporting the Function that generates logger,
we export an object that is both a Function _and_ a logger
without a prefix.

This way, existing code will be compatible without a change.
