### PR TITLE
Handle object with circular refs

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,9 @@
+{
+  "brace_style": "collapse-preserve-inline",
+  "end_with_newline": true,
+  "indent_char": " ",
+  "indent_size": 4,
+  "jslint_happy": false,
+  "space_after_anon_function": false,
+  "space_before_conditional": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -8,21 +8,5 @@
     "node": true,
     "strict": false,
     "sub": true,
-    "esversion" : 6,
-    "globals": {
-        "__dirname": true,
-        "before": true,
-        "beforeEach": true,
-        "Buffer": true,
-        "describe": true,
-        "expect": true,
-        "exports": true,
-        "it": true,
-        "jasmine": true,
-        "process": true,
-        "resourcesUrlBase": true,
-        "serverUrlBase": true,
-        "servicesUrlBase": true,
-        "xdescribe": true
-    }
+    "esversion" : 6
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,28 @@
+{
+    // Details: https://github.com/victorporof/Sublime-JSHint#using-your-own-jshintrc-options
+    // Example: https://github.com/jshint/jshint/blob/master/examples/.jshintrc
+    // Documentation: http://www.jshint.com/docs/
+    "undef": true,
+    "unused": "vars",
+    "laxbreak": true,
+    "node": true,
+    "strict": false,
+    "sub": true,
+    "esversion" : 6,
+    "globals": {
+        "__dirname": true,
+        "before": true,
+        "beforeEach": true,
+        "Buffer": true,
+        "describe": true,
+        "expect": true,
+        "exports": true,
+        "it": true,
+        "jasmine": true,
+        "process": true,
+        "resourcesUrlBase": true,
+        "serverUrlBase": true,
+        "servicesUrlBase": true,
+        "xdescribe": true
+    }
+}

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -1,9 +1,9 @@
-var _ = require("lodash");
+const _ = require("lodash");
 
-var level = 0;
-var _logger;
+let level = 0;
+let _logger;
 
-var KEYS_TO_HIDE = ["pass", "secret"];
+let KEYS_TO_HIDE = ["pass", "secret"];
 
 // Just display "useful" information about the configuration
 module.exports = function(logger, app, configuration) {
@@ -11,19 +11,18 @@ module.exports = function(logger, app, configuration) {
     if (configuration.logging.keysToHide) {
         KEYS_TO_HIDE = configuration.logging.keysToHide;
     }
-    var splash = app.get("name") + " configuration -------------\n";
-    splash += logObject(configuration);
-    splash += " ------------------------------------------------\n";
+    var splash = `${app.get("name")} configuration -------------
+${logObject(configuration)}
+ ------------------------------------------------`;
     _logger.notice(splash);
 };
 
 function logObject(configuration) {
 
-
     var result = "";
     level++;
 
-    _.forEach(configuration, function(value, key) {
+    _.forEach(configuration, (value, key) => {
         if (_.isArray(value)) {
             if (level === 1) {
                 result += blankLine();
@@ -47,24 +46,25 @@ function logObject(configuration) {
 }
 
 function valueToShow(key, value) {
-    var hideValue = _.reduce(KEYS_TO_HIDE, function(memo, keyToHide) {
-        var regExp = new RegExp(".*" + keyToHide + ".*", "i");
-        return memo || (key.match(regExp) !== null);
-    }, false);
 
-    return hideValue ? "****" : value;
+    const isKeyASecret = (memo, keyToHide) => {
+        // Does the key match one of the hidden keys pattern
+        return memo || (key.match(new RegExp(`.*${keyToHide}.*`, "i")) !== null);
+    };
+
+    return _.reduce(KEYS_TO_HIDE, isKeyASecret, false) ? "****" : value;
 }
 
 function logKey(key) {
-    return "| " + indent() + " " + key + "\n";
+    return `| ${indent()} ${key} \n`;
 }
 
 function logValue(key, value) {
-    return "| " + indent() + " " + key + ": " + valueToShow(key, value) + "\n";
+    return `| ${indent()} ${key}: ${valueToShow(key, value)} \n`;
 }
 
 function logArray(key, value) {
-    return "| " + indent() + " " + key + ": [" + valueToShow(key, value) + "]\n";
+    return `| ${indent()} ${key}: [${valueToShow(key, value)}] \n`;
 }
 
 function blankLine() {

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -47,12 +47,12 @@ function logObject(configuration) {
 
 function valueToShow(key, value) {
 
-    const isKeyASecret = (memo, keyToHide) => {
+    const isKeyASecret = (keyToHide) => {
         // Does the key match one of the hidden keys pattern
-        return memo || (key.match(new RegExp(`.*${keyToHide}.*`, "i")) !== null);
+        return key.match(new RegExp(`.*${keyToHide}.*`, "i")) !== null;
     };
 
-    return _.reduce(KEYS_TO_HIDE, isKeyASecret, false) ? "****" : value;
+    return _.some(KEYS_TO_HIDE, isKeyASecret) ? "****" : value;
 }
 
 function logKey(key) {

--- a/package.json
+++ b/package.json
@@ -1,32 +1,34 @@
 {
-  "name": "node-tech-logger",
-  "version": "3.0.1",
-  "description": "Winston logger customized for AirVantage",
-  "license": "MIT",
-  "main": "techLogger.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/AirVantage/node-tech-logger.git"
-  },
-  "scripts": {
-    "test": "export NODE_CONFIG_DIR=test/config;node test/testSplash.js"
-  },
-  "keywords": [
-    "logger",
-    "winston"
-  ],
-  "dependencies": {
-    "lodash": "^4.16.0",
-    "winston": "^0.8.1"
-  },
-  "optionalDependencies": {
-    "winston-syslog": "^1.2.5"
-  },
-  "devDependencies": {
-    "config": "^1.11.0",
-    "js-yaml": "^3.2.2",
-    "grunt": "^0.4.5",
-    "grunt-release": "^0.11.0",
-    "grunt-tag": "^0.1.0"
-  }
+    "name": "node-tech-logger",
+    "version": "3.0.1",
+    "description": "Winston logger customized for AirVantage",
+    "license": "MIT",
+    "main": "techLogger.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/AirVantage/node-tech-logger.git"
+    },
+    "scripts": {
+        "test": "export NODE_CONFIG_DIR=test/config;node test/testSplash.js && node test/testLogger.js"
+    },
+    "keywords": [
+        "logger",
+        "winston"
+    ],
+    "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.16.0",
+        "typeof--": "^1.3.3",
+        "winston": "^0.8.1"
+    },
+    "optionalDependencies": {
+        "winston-syslog": "^1.2.5"
+    },
+    "devDependencies": {
+        "config": "^1.11.0",
+        "grunt": "^0.4.5",
+        "grunt-release": "^0.11.0",
+        "grunt-tag": "^0.1.0",
+        "js-yaml": "^3.2.2"
+    }
 }

--- a/techLogger.js
+++ b/techLogger.js
@@ -139,11 +139,22 @@ function _doLog(log) {
  */
 function _log(level, log) {
 
-    var message = log.map(function(element) {
+    const toString = object => {
+        return stringify(object, (key, value) => {
+            // Do not process inner objects with a type named xxxStream
+            if (typof(value).indexOf("Stream") !== -1) {
+                return "[Stream ~]";
+            }
+            return value;
+        });
+    };
+
+
+    var message = log.map(element => {
         if (element instanceof Error) {
             return element.stack;
         } else if (typeof element !== "string") {
-            return JSON.stringify(element);
+            return toString(element);
         } else {
             return element;
         }

--- a/test/config/default.yml
+++ b/test/config/default.yml
@@ -24,3 +24,6 @@ api:
   portal:
     serverUrl : http://localhost:8080
 
+fakeCredentials:
+  user: "sebz"
+  password: "guessWhat!"

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -55,3 +55,11 @@ circularObj.list = [circularObj, circularObj];
 logger1.info("The following object contains a circular ref and nothing's blowing up \\o/  \n", circularObj);
 logger2.info("The following object contains a circular ref and nothing's blowing up \\o/ \n", circularObj);
 logger3.info("The following object contains a circular ref and nothing's blowing up \\o/ \n", circularObj);
+
+// Object of xxxStream type
+class TestStream {}
+var testStream = new TestStream();
+
+logger1.info("The following object is a TestStream and I will not log it \\o/  \n", testStream);
+logger2.info("The following object is a TestStream and I will not log it \\o/  \n", testStream);
+logger3.info("The following object is a TestStream and I will not log it \\o/  \n", testStream);

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -1,8 +1,8 @@
-var configuration = require("config");
+const configuration = require("config");
 
-var logger1 = require("../techLogger")("logger1");
-var logger2 = require("../techLogger")();
-var logger3 = require("../techLogger"); // Look ma, same conf as earlier
+const logger1 = require("../techLogger")("logger1");
+const logger2 = require("../techLogger")();
+const logger3 = require("../techLogger"); // Look ma, same conf as earlier
 
 logger1.setup(configuration.logging);
 logger2.setup(configuration.logging);
@@ -27,7 +27,7 @@ logger1.error("This is an error log");
 logger2.error("This is an error log");
 logger3.error("This is an error log");
 
-var apiError = {
+const apiError = {
     message: "API error message"
 };
 

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -46,3 +46,12 @@ logger3.alert("This is an alert log");
 logger1.emerg("This is an emergency log");
 logger2.emerg("This is an emergency log");
 logger3.emerg("This is an emergency log");
+
+//  Circular references support
+const circularObj = {};
+circularObj.circularRef = circularObj;
+circularObj.list = [circularObj, circularObj];
+
+logger1.info("The following object contains a circular ref and nothing's blowing up \\o/  \n", circularObj);
+logger2.info("The following object contains a circular ref and nothing's blowing up \\o/ \n", circularObj);
+logger3.info("The following object contains a circular ref and nothing's blowing up \\o/ \n", circularObj);

--- a/test/testSplash.js
+++ b/test/testSplash.js
@@ -1,10 +1,8 @@
-var configuration = require("config");
-var logger = require("../techLogger");
+const configuration = require("config");
+const logger = require("../techLogger");
 
-var app = {
-    get: function() {
-        return "Test Splash";
-    }
+const app = {
+    get: () => "Test Splash"
 };
 
 logger.setup(configuration.logging);


### PR DESCRIPTION
Properly handle printing of objects containing circular references.

#### Changes proposed in this pull-request
Default `JSON.stringify` implementation throws `TypeError: Converting circular structure to JSON` we now use https://github.com/isaacs/json-stringify-safe that displays `"[Circular ~]"` for these values.

I've also decided to also ignore values with type name containing `Stream` to avoid lot of stuff in the console/loggly.  Instead `[Stream ~]"` will be displayed.

As bonus I've migrated this module to ES6, added some "tests", added config files for JSHint and code formatting. 

#### Version bump
minor

#### One more thing
I've organized everything in 3 different commits to ease the review :kissing_heart: 